### PR TITLE
docker: add multi-stage Dockerfile for ws service

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,0 +1,28 @@
+#Builder Stage
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+COPY package.* .
+COPY . .
+
+ENV PATH="/app/node_modules/.bin:/app/packages/logger/node_modules/.bin:/app/apps/api/node_modules/.bin:$PATH"
+
+RUN npm install
+RUN npm run build --workspace=@quick-sync/logger
+RUN npm run build --workspace=@quick-sync/session-api
+
+#Runtime
+
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY --from=builder /app/apps/api/package.json .
+COPY --from=builder /app/apps/api/dist/ /app/dist/
+COPY --from=builder /app/node_modules /app/node_modules
+COPY --from=builder /app/packages/logger /app/packages/logger
+
+EXPOSE 2000
+
+CMD ["npm","run","start"]

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -16,7 +16,7 @@
   "description": "Express+Socket.IO session storage API for Quick Sync",
   "license": "MIT",
   "dependencies": {
-    "@quick-sync/logger": "*",
+    "@quick-sync/logger": "workspace:*",
     "cors": "^2.8.5",
     "express": "^5.1.0",
     "mongoose": "^8.13.2",

--- a/apps/ws/Dockerfile
+++ b/apps/ws/Dockerfile
@@ -1,0 +1,38 @@
+#Builder Stage
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+COPY package.json ./
+
+COPY apps/ws/package.json apps/ws/package.json
+COPY packages/logger/package.json packages/logger/package.json
+
+RUN npm install
+
+COPY apps/ws ./apps/ws
+COPY packages/logger ./packages/logger
+
+RUN npm run build --workspace=@quick-sync/logger
+RUN npm run build --workspace=@quick-sync/ws-server
+
+#Runtime
+
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY --from=builder /app/package.json .
+COPY --from=builder /app/apps/ws/package.json .
+COPY --from=builder /app/apps/ws/dist /app/dist
+COPY --from=builder /app/packages/logger /app/packages/logger
+COPY --from=builder /app/node_modules ./node_modules
+
+RUN addgroup -S nodejs && adduser -S nodejs -G nodejs
+RUN chown -R nodejs:nodejs /app
+USER nodejs
+
+EXPOSE 3000
+
+CMD ["node", "dist/index.js"]
+

--- a/apps/ws/package.json
+++ b/apps/ws/package.json
@@ -14,7 +14,8 @@
   "license": "MIT",
   "description": "WebSocket signaling server for Quick Sync",
   "dependencies": {
-    "ws": "^8.18.1"
+    "ws": "^8.18.1",
+    "@quick-sync/logger": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "^22.14.1",


### PR DESCRIPTION
## What this PR does

- Adds a Dockerfile for the `ws` (WebSocket) service
- Builds the ws server using npm workspaces
- Ensures the internal `@quick-sync/logger` dependency is resolved via `workspace:*`
- Produces a runnable container for the ws service

## Notes

- This PR focuses only on containerizing the ws service
- API and other services are handled in separate PRs
- Logger is treated as an internal workspace dependency (not published)

## How to run
docker build -f apps/ws/Dockerfile -t quicksync-ws .
docker run -p 3000:3000 quicksync-ws


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added containerization for API (port 2000) and WebSocket (port 3000) services using multi-stage builds for smaller, faster images
  * Included production-ready runtime setup with a non-root user for improved security
  * Updated workspace dependency handling to ensure consistent local package integration and removed an unused package dependency
<!-- end of auto-generated comment: release notes by coderabbit.ai -->